### PR TITLE
Replace traditional loops with Java 8 Streams API

### DIFF
--- a/src/main/java/tinman/task/TaskList.java
+++ b/src/main/java/tinman/task/TaskList.java
@@ -1,6 +1,8 @@
 package tinman.task;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import tinman.exception.TinManException;
 
@@ -78,11 +80,12 @@ public class TaskList {
         if (tasks.isEmpty()) {
             return "Here are the tasks in your list:\n (empty)";
         }
-        StringBuilder taskList = new StringBuilder("Here are the tasks in your list:");
-        for (int i = 0; i < tasks.size(); i++) {
-            taskList.append("\n ").append(i + 1).append(".").append(tasks.get(i));
-        }
-        return taskList.toString();
+
+        String taskListBody = IntStream.range(0, tasks.size())
+                .mapToObj(i -> "\n " + (i + 1) + "." + tasks.get(i))
+                .collect(Collectors.joining());
+
+        return "Here are the tasks in your list:" + taskListBody;
     }
 
     public ArrayList<Task> getTasks() {
@@ -96,14 +99,31 @@ public class TaskList {
      * @return List of tasks that match the keyword.
      */
     public ArrayList<Task> findTasks(String keyword) {
-        ArrayList<Task> matchingTasks = new ArrayList<>();
         String lowerKeyword = keyword.toLowerCase().trim();
 
-        for (Task task : tasks) {
-            if (task.getDescription().toLowerCase().contains(lowerKeyword)) {
-                matchingTasks.add(task);
-            }
-        }
-        return matchingTasks;
+        return tasks.stream()
+                .filter(task -> task.getDescription().toLowerCase().contains(lowerKeyword))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Checks if any task in the list is marked as done.
+     *
+     * @return true if at least one task is done, false otherwise.
+     */
+    public boolean hasCompletedTasks() {
+        return tasks.stream()
+                .anyMatch(Task::getIsDone);
+    }
+
+    /**
+     * Returns the count of completed tasks using streams.
+     *
+     * @return Number of completed tasks.
+     */
+    public long getCompletedTaskCount() {
+        return tasks.stream()
+                .filter(Task::getIsDone)
+                .count();
     }
 }


### PR DESCRIPTION
The existing code uses traditional for-loops and imperative style for collection operations like filtering and mapping.

Modern Java applications benefit from the declarative style and improved readability that streams provide. Streams also offer better performance potential through lazy evaluation.

Replace key collection operations with streams:
- TaskList.findTasks(): Use filter() and collect() for task searching
- TaskList.listTasks(): Use IntStream and mapToObj() for formatting
- Storage.load(): Use filter() and map() for file line processing
- Add stream methods: hasCompletedTasks() and getCompletedTaskCount()

The parseTaskFromLine() helper method cleanly wraps checked exceptions for use in streams, maintaining separation of concerns.